### PR TITLE
Fix: Corrected import paths for lerobot library in train.py and data.py

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,7 +1,7 @@
 import argparse, pathlib, re, sys, warnings, cv2, numpy as np, pandas as pd
 from typing import Dict, List, Tuple
 import glob
-from lerobot.common.datasets.lerobot_dataset import LeRobotDatasetMetadata, LeRobotDataset
+from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata, LeRobotDataset
 import os
 import json
 import shutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ google-generativeai
 pydantic
 streamlit
 plotly
+dotenv
+uniplot

--- a/train.py
+++ b/train.py
@@ -2,7 +2,7 @@ from lerobot.scripts import train as lerobot_train
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.configs.default import DatasetConfig, EvalConfig, WandBConfig
 #from lerobot.envs.factory import make_env_config
-from lerobot.common.policies.factory import make_policy_config
+from lerobot.policies.factory import make_policy_config
 import os
 from pathlib import Path
 import wandb


### PR DESCRIPTION
The common subdirectory has been depreciated in the most recent lerobot directory:

https://github.com/huggingface/lerobot/tree/main/src/lerobot