### PR TITLE
Update score_dataset.py to support output_dir flag

### DIFF
--- a/score_dataset.py
+++ b/score_dataset.py
@@ -55,6 +55,7 @@ def main():
     ap.add_argument("--plot", required=False, type=bool, default=False)
     args = ap.parse_args()
 
+
     # Load dataset.
     dataset = load_dataset_hf(args.repo_id, root=args.root)
     task = dataset.meta.tasks
@@ -152,9 +153,9 @@ def main():
     #  --wandb.enable=true
     
     if args.train_baseline:
-        start_training(args.repo_id, root=args.root, job_name='baseline', output_dir='./checkpoints/baseline')
+        start_training(args.repo_id, root=args.root, job_name='baseline')
     if args.train_filtered:
-        start_training(args.repo_id, root=args.output, job_name='filtered', output_dir='./checkpoints/filtered')
+        start_training(args.repo_id, root=args.output, job_name='filtered')
 
     if args.plot:
         for k in crit_names:


### PR DESCRIPTION
removed the hard-coded output directories from lines 155/157, this relies on the code of lines 20-24 of train.py to create a path location depending on the job name and repo name.

Otherwise this may cause errors when running parallel jobs since line 110 of lerobot's train script:

https://github.com/huggingface/lerobot/blob/main/src/lerobot/scripts/train.py

will through an error when the hard-coded path location is non-empty