### PR TITLE
Remove output path if it exists

### DIFF
--- a/data.py
+++ b/data.py
@@ -89,9 +89,14 @@ def rewrite_episode_parquet(old_parquet_path, new_parquet_path, good_episodes, s
     return n  # rows written
 
 
-def save_filtered_dataset(input_path, output_path, good_episodes):
+def save_filtered_dataset(input_path, output_path, good_episodes, overwrite=True):
     if os.path.exists(input_path) and os.path.exists(output_path) and os.path.samefile(input_path, output_path):
         raise ValueError(f'Input and output path cannot be identical. Input path: {input_path} \nOutput path: {output_path}')
+    if not overwrite and os.path.exists(output_path):
+        raise FileExistsError(f'Directory {output_path} already exists and overwite is False')
+    elif os.path.exists(output_path):
+        print(f'Removing directory: {output_path}')
+        shutil.rmtree(output_path)
     good_episodes = sorted(list(set(good_episodes)))
     # Read meta/info.json
     info_path = os.path.join(input_path, 'meta/info.json')

--- a/score_dataset.py
+++ b/score_dataset.py
@@ -50,6 +50,7 @@ def main():
     ap.add_argument("--repo_id", required=True, type=str)
     ap.add_argument("--root", required=False, default=None, type=str)
     ap.add_argument("--output", required=False, type=str, default=None)
+    ap.add_argument("--overwrite", required=False, type=bool, default=True)
     ap.add_argument("--nominal", type=float)
     ap.add_argument("--policy_name", type = str, default = "act")
     ap.add_argument("--threshold", type = float, default = 0.5)
@@ -152,7 +153,7 @@ def main():
         if not dataset_path:
             cache_dir = cache_dir = HF_LEROBOT_HOME
             dataset_path = os.path.join(cache_dir, args.repo_id)
-        save_filtered_dataset(dataset_path, args.output, good_episodes_list)
+        save_filtered_dataset(dataset_path, args.output, good_episodes_list, overwrite=args.overwrite)
         ds = load_dataset_hf(args.repo_id, root=args.output)
 
     # Training config required args.


### PR DESCRIPTION
This change either overwrites the existing output path or throws an error depending on if the overwrite flag is set.