### PR TITLE
Add overwrite flag for checkpoints directory

### DIFF
--- a/score_dataset.py
+++ b/score_dataset.py
@@ -168,13 +168,13 @@ def main():
     if args.train_baseline:
         if args.overwrite_checkpoints:
             print('WARNING: overwrite_checkpoints is True')
-        start_training(args.repo_id, root=args.root, job_name='baseline', overwrite_checkpoint=args.overwrite_checkpoint)
+        start_training(args.repo_id, root=args.root, policy_name=args.policy_name, job_name='baseline', overwrite_checkpoint=args.overwrite_checkpoint)
     if args.train_filtered and num_removed == 0:
         print('WARNING: Not training because nothing was removed.')
     elif args.train_filtered:
         if args.overwrite_checkpoints:
             print('WARNING: overwrite_checkpoints is True')
-        start_training(args.repo_id, root=args.output, job_name='filtered', overwrite_checkpoint=args.overwrite_checkpoint))
+        start_training(args.repo_id, root=args.output, policy_name=args.policy_name, job_name='filtered', overwrite_checkpoint=args.overwrite_checkpoint))
 
     if args.plot:
         for k in crit_names:

--- a/score_dataset.py
+++ b/score_dataset.py
@@ -166,14 +166,10 @@ def main():
     #  --wandb.enable=true
     
     if args.train_baseline:
-        if args.overwrite_checkpoints:
-            print('WARNING: overwrite_checkpoints is True')
         start_training(args.repo_id, root=args.root, policy_name=args.policy_name, job_name='baseline', overwrite_checkpoint=args.overwrite_checkpoint)
     if args.train_filtered and num_removed == 0:
         print('WARNING: Not training because nothing was removed.')
     elif args.train_filtered:
-        if args.overwrite_checkpoints:
-            print('WARNING: overwrite_checkpoints is True')
         start_training(args.repo_id, root=args.output, policy_name=args.policy_name, job_name='filtered', overwrite_checkpoint=args.overwrite_checkpoint))
 
     if args.plot:

--- a/score_dataset.py
+++ b/score_dataset.py
@@ -51,7 +51,7 @@ def main():
     ap.add_argument("--root", required=False, default=None, type=str)
     ap.add_argument("--output", required=False, type=str, default=None)
     ap.add_argument("--overwrite", required=False, type=bool, default=True)
-    ap.add_argument("--overwrite_checkpoint", required=False, default=False)
+    ap.add_argument("--overwrite_checkpoint", required=False, type=bool, default=False)
     ap.add_argument("--nominal", type=float)
     ap.add_argument("--policy_name", type = str, default = "act")
     ap.add_argument("--threshold", type = float, default = 0.5)

--- a/score_dataset.py
+++ b/score_dataset.py
@@ -51,6 +51,7 @@ def main():
     ap.add_argument("--root", required=False, default=None, type=str)
     ap.add_argument("--output", required=False, type=str, default=None)
     ap.add_argument("--overwrite", required=False, type=bool, default=True)
+    ap.add_argument("--overwrite_checkpoint", required=False, default=False)
     ap.add_argument("--nominal", type=float)
     ap.add_argument("--policy_name", type = str, default = "act")
     ap.add_argument("--threshold", type = float, default = 0.5)
@@ -165,11 +166,15 @@ def main():
     #  --wandb.enable=true
     
     if args.train_baseline:
-        start_training(args.repo_id, root=args.root, job_name='baseline')
+        if args.overwrite_checkpoints:
+            print('WARNING: overwrite_checkpoints is True')
+        start_training(args.repo_id, root=args.root, job_name='baseline', overwrite_checkpoint=args.overwrite_checkpoint)
     if args.train_filtered and num_removed == 0:
         print('WARNING: Not training because nothing was removed.')
     elif args.train_filtered:
-        start_training(args.repo_id, root=args.output, job_name='filtered')
+        if args.overwrite_checkpoints:
+            print('WARNING: overwrite_checkpoints is True')
+        start_training(args.repo_id, root=args.output, job_name='filtered', overwrite_checkpoint=args.overwrite_checkpoint))
 
     if args.plot:
         for k in crit_names:

--- a/train.py
+++ b/train.py
@@ -6,9 +6,10 @@ from lerobot.policies.factory import make_policy_config
 import os
 from pathlib import Path
 import wandb
+import shutil
 import torch
 
-def start_training(repo_id, root=None, output_dir=None, policy_name='act', job_name='', **kwargs):
+def start_training(repo_id, root=None, output_dir=None, policy_name='act', job_name='', overwrite_checkpoint=False, **kwargs):
     dataset = DatasetConfig(repo_id=repo_id, root=root)
     policy = make_policy_config(policy_name)
     policy.push_to_hub = False
@@ -22,6 +23,12 @@ def start_training(repo_id, root=None, output_dir=None, policy_name='act', job_n
 
     if not output_dir:
         output_dir = f'./checkpoints/{full_job_name}'
+
+    #lerobot_train will give an error if resume is False in train_config and output_dir is non-empty  
+    if overwrite_checkpoint and os.path.exists(output_dir):
+        print(f'Removing directory: {output_dir}')
+        shutil.rmtree(output_dir)
+    
     
     output_dir = Path(output_dir)
     wandb_config = WandBConfig(enable=True)


### PR DESCRIPTION
This creates a overwrite flag for the checkpoints directory. If resume is False in the TrainPipelineConfig and the directory for the saved checkpoints is non-empty then the training script from LeRobot: 

https://github.com/huggingface/lerobot/blob/main/src/lerobot/scripts/train.py

will provide an error due to cfg.validate() in line 110