### PR TITLE
Added fix for OpenX datasets

### DIFF
--- a/data.py
+++ b/data.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 def update_info_json(info_file):
     # This is required for OpenX datasets since
     # they store the channel name as rgb instead of channels.
+    # TODO: Remove this later and fix dataset.
     data = json.load(open(info_file, 'r'))
     for key in data['features']:
         if data['features'][key]['dtype'] != 'video':


### PR DESCRIPTION
This is a hyperspecific fix for the OpenX datasets.

We should ideally fix this on the dataset level but since we're actively using the OpenX datasets, it serves a purpose in the short term. Added a TODO to remove it during the next cleanup.


Error occurs on line 53 in the file /lerobot/policies/normalize.py:

`in create_stats_buffers assert c < h and c < w, f"{key} is not channel first ({shape=})" AssertionError: observation.images.image is not channel first (shape=(480, 640, 3))`