### PR TITLE
Feature/update visualize quantile

### DIFF
--- a/scripts/visualize_quantile.py
+++ b/scripts/visualize_quantile.py
@@ -31,7 +31,6 @@ def get_quantiles(results_path, num_quantiles=4, keep_camera=True, col = "aggreg
         .reset_index()
     )
     episode_scores.rename(columns={col: "mean_score"}, inplace=True)
-    episode_scores.to_csv("results2.csv")
 
     # assign quantiles
     quantiles, bin_edges = pd.qcut(

--- a/scripts/visualize_quantile.py
+++ b/scripts/visualize_quantile.py
@@ -21,7 +21,7 @@ def get_pandas_df(results_path):
     df_expanded = pd.concat([df.drop(columns= ["per_attribute_scores"]), df["per_attribute_scores"].apply(pd.Series)], axis = 1)
     return df_expanded
 
-def get_quantiles(results_path, num_quantiles=4, keep_camera=True, col = "aggregate_score", csv = False):
+def get_quantiles(results_path, num_quantiles=4, keep_camera=True, col = "aggregate_score"):
     df = get_pandas_df(results_path)
 
     # mean score per episode
@@ -50,8 +50,6 @@ def get_quantiles(results_path, num_quantiles=4, keep_camera=True, col = "aggreg
         )
     else:
         df_with_quantiles = episode_scores
-    if csv:
-        df_with_quantiles.to_csv("results3.csv")
 
     return df_with_quantiles, bin_edges
 

--- a/scripts/visualize_quantile.py
+++ b/scripts/visualize_quantile.py
@@ -132,7 +132,7 @@ def main():
     else:
         save_dir = "saved_examples"
         os.makedirs(save_dir, exist_ok=True)
-        save_path = os.path.join(save_dir, f"{repo_name}_examples")
+        save_path = os.path.join(save_dir, f"{repo_name}_{args.type}_examples")
         os.makedirs(save_path, exist_ok=True)
     
     #sample episodes from the picked quantile

--- a/scripts/visualize_quantile.py
+++ b/scripts/visualize_quantile.py
@@ -17,19 +17,21 @@ def get_pandas_df(results_path):
             data = json.load(f)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in results file: {results_path}") from e
-        
-    return pd.DataFrame(data)
+    df = pd.DataFrame(data)
+    df_expanded = pd.concat([df.drop(columns= ["per_attribute_scores"]), df["per_attribute_scores"].apply(pd.Series)], axis = 1)
+    return df_expanded
 
-def get_quantiles(results_path, num_quantiles=4, keep_camera=True):
+def get_quantiles(results_path, num_quantiles=4, keep_camera=True, col = "aggregate_score", csv = False):
     df = get_pandas_df(results_path)
 
     # mean score per episode
     episode_scores = (
-        df.groupby("episode_id")["aggregate_score"]
+        df.groupby("episode_id")[col]
         .mean()
         .reset_index()
     )
-    episode_scores.rename(columns={"aggregate_score": "mean_score"}, inplace=True)
+    episode_scores.rename(columns={col: "mean_score"}, inplace=True)
+    episode_scores.to_csv("results2.csv")
 
     # assign quantiles
     quantiles, bin_edges = pd.qcut(
@@ -48,57 +50,96 @@ def get_quantiles(results_path, num_quantiles=4, keep_camera=True):
         )
     else:
         df_with_quantiles = episode_scores
+    if csv:
+        df_with_quantiles.to_csv("results3.csv")
 
     return df_with_quantiles, bin_edges
 
 
-def visualize_quantile(df, quantile_pick=0, n_samples=3):
+def visualize_quantile(df, quantile_pick=0, n_samples=3, save_path = None):
     lowest = df[df["quantile"] == quantile_pick]
     
     # pick unique episodes
-    sampled_eps = lowest["episode_id"].drop_duplicates().sample(n=n_samples, random_state=42)
-    
+    sampled_eps = lowest["episode_id"].sample(n=n_samples, random_state=42)
+
     for ep in sampled_eps:
-        vid_path = lowest[lowest["episode_id"] == ep]["video_path"].iloc[0]
-        print(f"Episode {ep}, video: {vid_path}")
-        
-        clip = VideoFileClip(vid_path)  # full clip
-        temp_file = f"episode_{ep:06d}.mp4"
-        clip.write_videofile(temp_file, codec="libx264")
-        clip.close()
-        os.system(f"open {temp_file}")
+        episode_rows = lowest[lowest["episode_id"] == ep]
+
+        for _, row in episode_rows.iterrows():
+            vid_path = row["video_path"]
+            cam_type = row["camera_type"]
+            print(f"Episode {ep}, camera: {cam_type}, video: {vid_path}")
+
+            try:
+                clip = VideoFileClip(vid_path)  # full clip
+                filename = f"episode_{ep:06d}_{cam_type}.mp4"
+
+                if save_path:
+                    out_file = os.path.join(save_path, filename)
+                else:
+                    out_file = filename
+                
+                #Save the video
+                clip.write_videofile(out_file, codec="libx264")
+                print(f"  Saved to: {out_file}")
+
+                #Open the video
+                os.system(f"open '{out_file}'")
+                clip.close()
+
+            #raise Exception if video file not found
+            except Exception as e:
+                print(f"  Error processing {vid_path}: {str(e)}")
+                continue
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo_id", required=True, type=str)
     ap.add_argument("--results_path", required=False, default=None, type=str)
+    ap.add_argument("--save_path", required=False, default=None, type=str)
     ap.add_argument("--quantiles", type = int, default = 4)
     ap.add_argument("--quantile_pick", type = int, default = 0)
     ap.add_argument("--num_samples", type = int, default = 3)
+    ap.add_argument("--type", required=False, choices=["aggregate_score", "visual_clarity", "smoothness", "collision"], default="aggregate_score")
+    ap.add_argument("--csv", type=bool, default=False)
     args = ap.parse_args()
+
+    #set repo_name
+    repo_name = args.repo_id.replace("/", "_")
 
     #load JSON results
     if args.results_path:
         results_path = args.results_path
+        
+
     #if results path not provided, we consider the default path given by score_dataset.py
     else:
         results_dir = "results"
         os.makedirs(results_dir, exist_ok=True)
-        repo_name = args.repo_id.replace("/", "_")
         results_path = os.path.join(results_dir, f"{repo_name}_scores.json")
     
     print(f"Using results file: {results_path}")
     
     #get quantiles:
-    df, quantiles = get_quantiles(results_path, num_quantiles = args.quantiles)
+    df, quantiles = get_quantiles(results_path, num_quantiles = args.quantiles, col = args.type, csv = args.csv)
+
+    if args.csv:
+        csv_path = f'{repo_name}_quantiles.csv'
+        df.to_csv(csv_path, index=False)
 
     for i, edge in enumerate(quantiles):
         print(f"Quantile {i} cutoff: {edge}")
     
-
+    if args.save_path:
+        save_path = args.save_path
+    else:
+        save_dir = "saved_examples"
+        os.makedirs(save_dir, exist_ok=True)
+        save_path = os.path.join(save_dir, f"{repo_name}_examples")
+        os.makedirs(save_path, exist_ok=True)
+    
     #sample episodes from the picked quantile
-    visualize_quantile(df, quantile_pick=args.quantile_pick, n_samples=args.num_samples)
-
+    visualize_quantile(df, quantile_pick=args.quantile_pick, n_samples=args.num_samples, save_path = save_path)
 
 
 if __name__ == "__main__":

--- a/scripts/visualize_quantile.py
+++ b/scripts/visualize_quantile.py
@@ -119,7 +119,7 @@ def main():
     print(f"Using results file: {results_path}")
     
     #get quantiles:
-    df, quantiles = get_quantiles(results_path, num_quantiles = args.quantiles, col = args.type, csv = args.csv)
+    df, quantiles = get_quantiles(results_path, num_quantiles = args.quantiles, col = args.type)
 
     if args.csv:
         csv_path = f'{repo_name}_quantiles.csv'


### PR DESCRIPTION
This pull-request consists of the following changes:

1) Changes to get_pandas_df: The previous version had hashmaps in the "per_attribute_scores" column where the keys where the scoring criterions (visual clarity, smoothness, collision, etc). This version includes each of those scoring criterions as separate columns with values. This makes it easier to 

2) Changes to get_quantiles: can now choose different categories such as "aggregate_score", "visual_clarity", "smoothness", "collision" for quantile ranking.

3) Changes to visualize_quantile: Overall script is cleaner and more robust. We can now save examples to a specific directory and we now save all camera angles from a specific video.

4) Changes to main: Incorporate the above changes that also includes setting a default save path if none exists.