### PR TITLE
Add score_idle_time_velocity

### DIFF
--- a/score_dataset.py
+++ b/score_dataset.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple
 
 from vlm import VLMInterface
 from data import organize_by_episode, load_dataset_hf, save_filtered_dataset
-from scores import score_task_success, score_visual_clarity, score_smoothness, score_path_efficiency, score_collision, score_runtime, score_joint_stability, score_gripper_consistency
+from scores import score_task_success, score_visual_clarity, score_smoothness, score_path_efficiency, score_collision, score_runtime, score_joint_stability, score_gripper_consistency, score_idle_velocity
 from scores import build_time_stats           # (your helper from the other file)
 from train import start_training
 from evaluation import get_eval_episodes, run_eval

--- a/scores/__init__.py
+++ b/scores/__init__.py
@@ -1,7 +1,7 @@
 import cv2, numpy as np, pathlib
 
 from .visual import score_visual_clarity
-from .path import score_smoothness, score_path_efficiency, score_collision, score_joint_stability, score_gripper_consistency
+from .path import score_smoothness, score_path_efficiency, score_idle_velocity, score_collision, score_joint_stability, score_gripper_consistency
 
 def build_time_stats(states):
     """

--- a/scores/path.py
+++ b/scores/path.py
@@ -25,6 +25,20 @@ def score_path_efficiency(vp, sts, vlm, task, nom):
     scores = 0. if path < 1e-6 else float(np.clip(straight / path, 0., 1.))
     return np.mean(scores)
 
+def score_idle_velocity(vp, sts, vlm, task, nom):
+    threshold = 0.1
+    states = np.array([st.get("q") for st in sts])
+    timestamps = np.array([st["t"] for st in sts])
+    """Detect idle based on low velocity."""
+    velocities = np.diff(states, axis=0) / np.diff(timestamps)[:, None]
+    velocity_magnitude = np.linalg.norm(velocities, axis=1)
+    idle_mask = velocity_magnitude < threshold
+
+    #idle_time = np.sum(idle_mask * np.diff(timestamps))
+    idle_ratio = np.mean(idle_mask)
+
+    return 1-idle_ratio
+
 def score_collision(vp, sts, vlm, task, nom):
     states = np.array([st.get("q") for st in sts])
     timestamps = np.array([st["t"] for st in sts])


### PR DESCRIPTION
This pull-request adds a scoring function to record idle velocities of a robot's movement. 

The scoring function is defined in scores/path.py

The adjustments to scores/__init__.py and score_dataset.py allow for importing the function. 

The results look positive on the droid100 dataset: https://huggingface.co/datasets/lerobot/droid_100

where episodes such as episode 78 scored lower due to the times where the robot didn't appear to move. 
Uploading episode_000078.mp4…

